### PR TITLE
[FEAT] 산책 메이트 화면 동 검색, 현재 위치 방식 수정

### DIFF
--- a/client/src/components/DogFootLoading.js
+++ b/client/src/components/DogFootLoading.js
@@ -1,0 +1,52 @@
+import { IoPawSharp } from 'react-icons/io5';
+import styled from 'styled-components';
+
+const DogFootLoadingBox = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  width: max-content;
+  height: max-content;
+  background-color: white;
+  color: var(--main-font-color);
+  font-size: ${({ size }) => size || '1rem'};
+
+  > svg:first-child {
+    display: inline-block;
+    animation: wave 1s infinite;
+  }
+
+  > svg:nth-child(2) {
+    display: inline-block;
+    animation: wave 1s infinite;
+    animation-delay: 0.1s;
+  }
+
+  > svg:nth-child(3) {
+    display: inline-block;
+    animation: wave 1s infinite;
+    animation-delay: 0.2s;
+  }
+
+  @keyframes wave {
+    0%,
+    40%,
+    100% {
+      transform: translateY(0);
+    }
+    20% {
+      transform: translateY(-5px);
+    }
+  }
+`;
+const DogFootLoading = ({ size }) => {
+  return (
+    <DogFootLoadingBox size={size}>
+      <IoPawSharp />
+      <IoPawSharp />
+      <IoPawSharp />
+    </DogFootLoadingBox>
+  );
+};
+
+export default DogFootLoading;

--- a/client/src/components/findMate/SearchAddress.js
+++ b/client/src/components/findMate/SearchAddress.js
@@ -4,12 +4,11 @@ import { IoLocationSharp } from 'react-icons/io5';
 import { BiTargetLock } from 'react-icons/bi';
 import { useRef, useState } from 'react';
 
-const SearchAddress = ({ setAddress, setBCode }) => {
+const SearchAddress = ({ setAddress, setBCode, setIsLoading }) => {
   const searchResultRef = useRef();
   const [searchAddress, setSearchAddress] = useState('');
   const [addressList, setAddressList] = useState([]);
   const [isAddressListOpen, setIsAddressListOpen] = useState(false);
-  const [isLocLoading, setIsLocLoading] = useState(false);
   // 검색 결과 창 밖 클릭하면 닫힘
   useOnClickOutside(searchResultRef, () => setIsAddressListOpen(false));
 
@@ -61,7 +60,7 @@ const SearchAddress = ({ setAddress, setBCode }) => {
             if (status === kakao.maps.services.Status.OK) {
               setBCode(result[0].code);
               setAddress(result[0].address_name);
-              setIsLocLoading(false);
+              setIsLoading(false);
             }
           };
 
@@ -80,15 +79,14 @@ const SearchAddress = ({ setAddress, setBCode }) => {
       if (e.target.value === '') {
         return;
       }
-
-      getAddressCode(e.target.value);
       setIsAddressListOpen(true);
+      getAddressCode(e.target.value);
     }
   };
 
   const handleLocClick = () => {
     geoFind();
-    setIsLocLoading(true);
+    setIsLoading(true);
   };
 
   const handleClickSearchResult = (index) => {
@@ -114,20 +112,10 @@ const SearchAddress = ({ setAddress, setBCode }) => {
         value={searchAddress}
         onChange={(e) => setSearchAddress(e.target.value)}
       ></AdderssInput>
-      {isLocLoading ? (
-        <LocationBox>
-          <BiTargetLock />
-          <WaveSpan delay="1">현</WaveSpan>
-          <WaveSpan delay="2">재</WaveSpan>
-          <WaveSpan delay="3">위</WaveSpan>
-          <WaveSpan delay="4">치</WaveSpan>
-        </LocationBox>
-      ) : (
-        <LocationButton onClick={handleLocClick}>
-          <BiTargetLock />
-          현재위치
-        </LocationButton>
-      )}
+      <LocationButton onClick={handleLocClick}>
+        <BiTargetLock />
+        현재위치
+      </LocationButton>
       {isAddressListOpen && (
         <SearchResultBox ref={searchResultRef}>
           {addressList.length === 0 ? (
@@ -152,6 +140,7 @@ const SearchAddress = ({ setAddress, setBCode }) => {
 };
 
 const SearchAddressBox = styled.div`
+  width: 100%;
   display: flex;
   align-items: center;
   background-color: #ffffff;
@@ -197,35 +186,6 @@ const LocationButton = styled.button`
   font-weight: 600;
   > svg {
     margin-right: 0.5rem;
-  }
-`;
-
-const LocationBox = styled.div`
-  display: flex;
-  align-items: center;
-  border: none;
-  background: none;
-  color: var(--main-font-color);
-  font-size: 1rem;
-  font-weight: 600;
-  > svg {
-    margin-right: 0.5rem;
-  }
-`;
-
-const WaveSpan = styled.span`
-  display: inline-block;
-  animation: wave 1s infinite;
-  animation-delay: ${(props) => `calc(${props.delay} * 0.1s)` || '0.1s'};
-  @keyframes wave {
-    0%,
-    40%,
-    100% {
-      transform: translateY(0);
-    }
-    20% {
-      transform: translateY(-3px);
-    }
   }
 `;
 

--- a/client/src/components/findMate/SearchAddressBox.js
+++ b/client/src/components/findMate/SearchAddressBox.js
@@ -6,10 +6,12 @@ import { useRef, useState } from 'react';
 
 const SearchAddress = ({ setAddress, setBCode }) => {
   const searchResultRef = useRef();
+  const [searchAddress, setSearchAddress] = useState('');
   const [addressList, setAddressList] = useState([]);
   const [isAddressListOpen, setIsAddressListOpen] = useState(false);
   // 검색 결과 창 밖 클릭하면 닫힘
   useOnClickOutside(searchResultRef, () => setIsAddressListOpen(false));
+
   // 주소 검색 함수
   const { kakao } = window;
 
@@ -37,11 +39,6 @@ const SearchAddress = ({ setAddress, setBCode }) => {
             return acc;
           }, [])
         );
-        // setAddressList(result);
-        // console.log('여기!', result);
-        // const bCode = result[0].address.b_code;
-        // console.log(result[0].address.address_name);
-        // console.log(bCode);
       }
     });
   };
@@ -82,8 +79,8 @@ const SearchAddress = ({ setAddress, setBCode }) => {
         return;
       }
 
-      setIsAddressListOpen(true);
       getAddressCode(e.target.value);
+      setIsAddressListOpen(true);
     }
   };
 
@@ -91,15 +88,28 @@ const SearchAddress = ({ setAddress, setBCode }) => {
     geoFind();
   };
 
-  const handleClick = () => {};
+  const handleClickSearchResult = (index) => {
+    // input value 초기화
+    setSearchAddress(addressList[index].addressName);
+    // 선택한 결과의 배열 index를 이용해 화면에 출력할 주소명과 서버에 보낼 법정 코드를 설정
+    // 주소명
+    setAddress(addressList[index].addressName);
+    // 법정 코드
+    setBCode(addressList[index].bCode);
+    // 검색창 닫고 초기화
+    setIsAddressListOpen(false);
+    setAddressList([]);
+  };
 
   return (
     <SearchAddressBox>
       <IoLocationSharp className="location-icon" />
       <AdderssInput
         type="text"
-        placeholder="시/도 또는 시/군/구 또는 읍/면/동 이름을 검색하세요"
+        placeholder="동 이름을 검색하세요"
         onKeyUp={handleSearchAddressKeyUp}
+        value={searchAddress}
+        onChange={(e) => setSearchAddress(e.target.value)}
       ></AdderssInput>
       <LocationButton onClick={handleLocClick}>
         <BiTargetLock />
@@ -112,7 +122,10 @@ const SearchAddress = ({ setAddress, setBCode }) => {
           ) : (
             <ul>
               {addressList.map((el, idx) => (
-                <SearchResultItem key={idx} onClick={handleClick}>
+                <SearchResultItem
+                  key={el.id}
+                  onClick={() => handleClickSearchResult(idx)}
+                >
                   <IoLocationSharp className="location-icon" />
                   {el.addressName}
                 </SearchResultItem>

--- a/client/src/components/findMate/SearchAddressBox.js
+++ b/client/src/components/findMate/SearchAddressBox.js
@@ -9,6 +9,7 @@ const SearchAddress = ({ setAddress, setBCode }) => {
   const [searchAddress, setSearchAddress] = useState('');
   const [addressList, setAddressList] = useState([]);
   const [isAddressListOpen, setIsAddressListOpen] = useState(false);
+  const [isLocLoading, setIsLocLoading] = useState(false);
   // 검색 결과 창 밖 클릭하면 닫힘
   useOnClickOutside(searchResultRef, () => setIsAddressListOpen(false));
 
@@ -60,6 +61,7 @@ const SearchAddress = ({ setAddress, setBCode }) => {
             if (status === kakao.maps.services.Status.OK) {
               setBCode(result[0].code);
               setAddress(result[0].address_name);
+              setIsLocLoading(false);
             }
           };
 
@@ -86,6 +88,7 @@ const SearchAddress = ({ setAddress, setBCode }) => {
 
   const handleLocClick = () => {
     geoFind();
+    setIsLocLoading(true);
   };
 
   const handleClickSearchResult = (index) => {
@@ -111,10 +114,20 @@ const SearchAddress = ({ setAddress, setBCode }) => {
         value={searchAddress}
         onChange={(e) => setSearchAddress(e.target.value)}
       ></AdderssInput>
-      <LocationButton onClick={handleLocClick}>
-        <BiTargetLock />
-        현재 위치
-      </LocationButton>
+      {isLocLoading ? (
+        <LocationBox>
+          <BiTargetLock />
+          <WaveSpan delay="1">현</WaveSpan>
+          <WaveSpan delay="2">재</WaveSpan>
+          <WaveSpan delay="3">위</WaveSpan>
+          <WaveSpan delay="4">치</WaveSpan>
+        </LocationBox>
+      ) : (
+        <LocationButton onClick={handleLocClick}>
+          <BiTargetLock />
+          현재위치
+        </LocationButton>
+      )}
       {isAddressListOpen && (
         <SearchResultBox ref={searchResultRef}>
           {addressList.length === 0 ? (
@@ -182,7 +195,38 @@ const LocationButton = styled.button`
   color: var(--main-font-color);
   font-size: 1rem;
   font-weight: 600;
-  gap: 8px;
+  > svg {
+    margin-right: 0.5rem;
+  }
+`;
+
+const LocationBox = styled.div`
+  display: flex;
+  align-items: center;
+  border: none;
+  background: none;
+  color: var(--main-font-color);
+  font-size: 1rem;
+  font-weight: 600;
+  > svg {
+    margin-right: 0.5rem;
+  }
+`;
+
+const WaveSpan = styled.span`
+  display: inline-block;
+  animation: wave 1s infinite;
+  animation-delay: ${(props) => `calc(${props.delay} * 0.1s)` || '0.1s'};
+  @keyframes wave {
+    0%,
+    40%,
+    100% {
+      transform: translateY(0);
+    }
+    20% {
+      transform: translateY(-3px);
+    }
+  }
 `;
 
 const SearchResultBox = styled.div`

--- a/client/src/components/findMate/SearchAddressBox.js
+++ b/client/src/components/findMate/SearchAddressBox.js
@@ -1,21 +1,40 @@
 import styled from 'styled-components';
 import { IoLocationSharp } from 'react-icons/io5';
 import { BiTargetLock } from 'react-icons/bi';
-// import { findMateGet } from '../../api/findMate';
+import { useState } from 'react';
 
-const SearchAddress = ({ setAddress }) => {
-  const handleKeyUp = (e) => {
-    if (e.key === 'Enter') {
-      if (e.target.value === '') {
-        return;
-      }
-      setAddress(e.target.value);
-    }
-  };
-
-  // 현재 위치로 목록 받아오기
+const SearchAddress = ({ setAddress, setBCode }) => {
+  const [addressList, setAddressList] = useState([
+    '안녕하세요',
+    '서울시 송파구 잠실7동',
+    '서울시 송파구 잠실7동',
+    '서울시 송파구 잠실7동',
+    '서울시 송파구 잠실7동',
+    '서울시 송파구 잠실7동',
+    '서울시 송파구 잠실7동',
+    '서울시 송파구 잠실7동',
+    '서울시 송파구 잠실7동',
+  ]);
   const { kakao } = window;
 
+  // 검색어로 주소 정보 받아오기
+  const getAddressCode = (address) => {
+    // 주소 - 좌표 변환 객체
+    const geocoder = new kakao.maps.services.Geocoder();
+
+    // 주소로 좌표 검색하기 -> 법정 코드 값 가져오기
+    geocoder.addressSearch(address, function (result, status) {
+      if (status === kakao.maps.services.Status.OK) {
+        setAddressList(result);
+        console.log('여기!', result);
+        // const bCode = result[0].address.b_code;
+        // console.log(result[0].address.address_name);
+        // console.log(bCode);
+      }
+    });
+  };
+
+  // 현재 위치로 주소 정보 받아오기
   const geoFind = () => {
     // 현재 위치 파악해서 x, y 좌표 얻기
     if (navigator.geolocation) {
@@ -30,7 +49,7 @@ const SearchAddress = ({ setAddress }) => {
 
           const callback = function (result, status) {
             if (status === kakao.maps.services.Status.OK) {
-              console.log('법정 코드', result[0].code);
+              setBCode(result[0].code);
               setAddress(result[0].address_name);
             }
           };
@@ -44,9 +63,22 @@ const SearchAddress = ({ setAddress }) => {
     }
   };
 
+  // 주소 검색
+  const handleSearchAddressKeyUp = (e) => {
+    if (e.key === 'Enter') {
+      if (e.target.value === '') {
+        return;
+      }
+
+      getAddressCode(e.target.value);
+    }
+  };
+
   const handleLocClick = () => {
     geoFind();
   };
+
+  const handleClick = () => {};
 
   return (
     <SearchAddressBox>
@@ -54,12 +86,26 @@ const SearchAddress = ({ setAddress }) => {
       <AdderssInput
         type="text"
         placeholder="시/도 또는 시/군/구 또는 읍/면/동 이름을 검색하세요"
-        onKeyUp={handleKeyUp}
+        onKeyUp={handleSearchAddressKeyUp}
       ></AdderssInput>
       <LocationButton onClick={handleLocClick}>
         <BiTargetLock />
         현재 위치
       </LocationButton>
+      <SearchResultBox>
+        {addressList.length === 0 ? (
+          <div>검색 결과가 없습니다.</div>
+        ) : (
+          <ul>
+            {addressList.map((el, idx) => (
+              <SearchResultItem key={idx} onClick={handleClick}>
+                <IoLocationSharp className="location-icon" />
+                {el}
+              </SearchResultItem>
+            ))}
+          </ul>
+        )}
+      </SearchResultBox>
     </SearchAddressBox>
   );
 };
@@ -109,6 +155,36 @@ const LocationButton = styled.button`
   font-size: 1rem;
   font-weight: 600;
   gap: 8px;
+`;
+
+const SearchResultBox = styled.div`
+  position: absolute;
+  z-index: 9;
+  background-color: white;
+  width: 100%;
+  height: max-content;
+  top: 3.6rem;
+  box-shadow: 2px 4px 4px rgba(0, 0, 0, 0.1);
+  padding: 1rem 1.25rem;
+  border-radius: 10px;
+
+  > div {
+    width: 100%;
+    color: var(--sec-color);
+  }
+`;
+
+const SearchResultItem = styled.div`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 0;
+  gap: 0.8rem;
+  color: var(--sec-color);
+
+  &:hover {
+    color: var(--main-font-color);
+  }
 `;
 
 export default SearchAddress;

--- a/client/src/components/findMate/SearchAddressBox.js
+++ b/client/src/components/findMate/SearchAddressBox.js
@@ -30,23 +30,9 @@ const SearchAddress = ({ setAddress }) => {
 
           const callback = function (result, status) {
             if (status === kakao.maps.services.Status.OK) {
-              console.log(result);
-              console.log(result[0]);
               console.log('법정 코드', result[0].code);
               setAddress(result[0].address_name);
             }
-
-            // 주소로 법정 코드 얻기
-            // geocoder.addressSearch(
-            //   result[0].address.address_name,
-            //   function (result, status) {
-            //     if (status === kakao.maps.services.Status.OK) {
-            //       const bCode = result[0].address.b_code;
-            //       console.log('법정 코드', bCode);
-            //       // findMateGet(bCode);
-            //     }
-            //   }
-            // );
           };
 
           geocoder.coord2RegionCode(coord.getLng(), coord.getLat(), callback);

--- a/client/src/components/findMate/SearchAddressBox.js
+++ b/client/src/components/findMate/SearchAddressBox.js
@@ -30,23 +30,26 @@ const SearchAddress = ({ setAddress }) => {
 
           const callback = function (result, status) {
             if (status === kakao.maps.services.Status.OK) {
-              console.log(result[0].address.address_name);
+              console.log(result);
+              console.log(result[0]);
+              console.log('법정 코드', result[0].code);
+              setAddress(result[0].address_name);
             }
 
             // 주소로 법정 코드 얻기
-            geocoder.addressSearch(
-              result[0].address.address_name,
-              function (result, status) {
-                if (status === kakao.maps.services.Status.OK) {
-                  const bCode = result[0].address.b_code;
-                  console.log('법정 코드', bCode);
-                  // findMateGet(bCode);
-                }
-              }
-            );
+            // geocoder.addressSearch(
+            //   result[0].address.address_name,
+            //   function (result, status) {
+            //     if (status === kakao.maps.services.Status.OK) {
+            //       const bCode = result[0].address.b_code;
+            //       console.log('법정 코드', bCode);
+            //       // findMateGet(bCode);
+            //     }
+            //   }
+            // );
           };
 
-          geocoder.coord2Address(coord.getLng(), coord.getLat(), callback);
+          geocoder.coord2RegionCode(coord.getLng(), coord.getLat(), callback);
         },
         (err) => {
           console.log(err.message);

--- a/client/src/pages/FindMatePage.js
+++ b/client/src/pages/FindMatePage.js
@@ -19,17 +19,17 @@ const FindMateTop = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  h1 {
+  > h1 {
     width: 100%;
     color: var(--main-font-color);
     font-size: 1rem;
     margin-bottom: 0.5rem;
   }
-  div {
+  > div {
     width: 100%;
   }
 
-  h2 {
+  > h2 {
     color: var(--main-font-color);
     font-size: 1.5rem;
   }

--- a/client/src/pages/FindMatePage.js
+++ b/client/src/pages/FindMatePage.js
@@ -2,10 +2,11 @@ import { useEffect, useState } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import styled from 'styled-components';
 import Container from '../components/Container';
-import SearchAddress from '../components/findMate/SearchAddressBox';
+import SearchAddress from '../components/findMate/SearchAddress';
 import FindMateTab from '../components/findMate/FindMateTab';
 import MateBoardConent from '../components/findMate/MateBoardContent';
 import MateMemberContent from '../components/findMate/MateMemberContent';
+import DogFootLoading from '../components/DogFootLoading';
 
 const FindMateContainer = styled(Container)`
   display: flex;
@@ -16,6 +17,7 @@ const FindMateContainer = styled(Container)`
 
 const FindMateTop = styled.div`
   width: 50%;
+  height: 10rem;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -25,10 +27,6 @@ const FindMateTop = styled.div`
     font-size: 1rem;
     margin-bottom: 0.5rem;
   }
-  > div {
-    width: 100%;
-  }
-
   > h2 {
     color: var(--main-font-color);
     font-size: 1.5rem;
@@ -42,6 +40,7 @@ const FindMateBottom = styled.div`
 const FindMatePage = () => {
   const [address, setAddress] = useState('');
   const [bCode, setBCode] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
     console.log('주소', address);
@@ -52,8 +51,12 @@ const FindMatePage = () => {
     <FindMateContainer>
       <FindMateTop>
         <h1>어떤 지역에서 찾고 싶으신가요?</h1>
-        <SearchAddress setAddress={setAddress} setBCode={setBCode} />
-        <h2>{address}</h2>
+        <SearchAddress
+          setAddress={setAddress}
+          setBCode={setBCode}
+          setIsLoading={setIsLoading}
+        />
+        {isLoading ? <DogFootLoading size="1.3rem" /> : <h2>{address}</h2>}
       </FindMateTop>
       <FindMateBottom>
         <FindMateTab />

--- a/client/src/pages/FindMatePage.js
+++ b/client/src/pages/FindMatePage.js
@@ -39,36 +39,29 @@ const FindMateBottom = styled.div`
   width: 100%;
 `;
 
-const { kakao } = window;
-
 const FindMatePage = () => {
   const [address, setAddress] = useState('');
+  const [bCode, setBCode] = useState('');
 
-  // 주소 - 좌표 변환 객체
-  const geocoder = new kakao.maps.services.Geocoder();
-
-  // 주소로 좌표 검색하기 -> 법정 코드 값 가져오기
   useEffect(() => {
-    geocoder.addressSearch(address, function (result, status) {
-      if (status === kakao.maps.services.Status.OK) {
-        const bCode = result[0].address.b_code;
-        console.log(result[0].address.address_name);
-        console.log(bCode);
-      }
-    });
-  });
+    console.log('주소', address);
+    console.log('법정 코드', bCode);
+  }, [address, bCode]);
 
   return (
     <FindMateContainer>
       <FindMateTop>
         <h1>어떤 지역에서 찾고 싶으신가요?</h1>
-        <SearchAddress setAddress={setAddress} />
-        {address ? <h2>{address}</h2> : <h2>송파구 잠실 7동</h2>}
+        <SearchAddress setAddress={setAddress} setBCode={setBCode} />
+        <h2>{address}</h2>
       </FindMateTop>
       <FindMateBottom>
         <FindMateTab />
         <Routes>
-          <Route path="members" element={<MateMemberContent />}></Route>
+          <Route
+            path="members"
+            element={<MateMemberContent code={bCode} />}
+          ></Route>
           <Route path="boards" element={<MateBoardConent />}></Route>
           <Route path="*" element={<MateMemberContent />}></Route>
         </Routes>


### PR DESCRIPTION
- 현재 위치 클릭 시 작동하는 카카오 method를 coord2RegionCode 방식으로 변경 ( 법정 코드, 동까지의 지번 주소 가져옴)
- 현재 위치 클릭 시 지연 시간이 있어 로딩 화면 추가
- 검색 창 -> 원하는 동 입력 시 검색 결과로 해당하는 지역의 목록이 뜨고 선택 시 결과에 적용됨
( 더 넓은 범위를 검색 시 범위 안의 모든 동이 뜨게 하는 기능은 추가적인 구현이 필요 Advanced )